### PR TITLE
Add vertical position indicator to medic body compass

### DIFF
--- a/scripting/c_dy_respawn_naong.sp
+++ b/scripting/c_dy_respawn_naong.sp
@@ -5286,7 +5286,7 @@ String:GetHeightString(Float:fClientPosition[3], Float:fTargetPosition[3])
         s = "LEVEL";
     }
     
-    return s
+    return s;
 }
 
 // Check tags

--- a/scripting/c_dy_respawn_naong.sp
+++ b/scripting/c_dy_respawn_naong.sp
@@ -5021,6 +5021,7 @@ public Action:Timer_NearestBody(Handle:timer, any:data)
 	
 	decl String:sDirection[64];
 	decl String:sDistance[64];
+    decl String:sHeight[6];
 
 	// Client loop
 	for (new medic = 1; medic <= MaxClients; medic++)
@@ -5088,10 +5089,13 @@ public Action:Timer_NearestBody(Handle:timer, any:data)
 				
 				// Get distance string
 				sDistance = GetDistanceString(fNearestDistance);
+
+                // Get height string
+                sHeight = GetHeightString(fMedicPosition, fInjuredPosition);
 				
 				// Print iNearestInjured dead body's distance and direction text
 				//PrintCenterText(medic, "Nearest dead: %N (%s)", iNearestInjured, sDistance);
-				PrintCenterText(medic, "Nearest dead: %N ( %s | %s )", iNearestInjured, sDistance, sDirection);
+				PrintCenterText(medic, "Nearest dead: %N ( %s | %s | %s )", iNearestInjured, sDistance, sDirection, sHeight);
 				new Float:beamPos[3];
 				beamPos = fInjuredPosition;
 				beamPos[2] += 0.3;
@@ -5256,6 +5260,33 @@ String:GetDistanceString(Float:fDistance)
 	}
 	
 	return sResult;
+}
+
+/**
+ * Get height string for nearest dead body
+ *
+ * @param fClientPosition[3]    Client position
+ * @param fTargetPosition[3]    Target position
+ * @Return                      height string.
+ */
+String:GetHeightString(Float:fClientPosition[3], Float:fTargetPosition[3])
+{
+    decl String:s[6];
+    
+    if (fClientPosition[2]+64 < fTargetPosition[2])
+    {
+        s = "ABOVE";
+    }
+    else if (fClientPosition[2]-64 > fTargetPosition[2])
+    {
+        s = "BELOW";
+    }
+    else
+    {
+        s = "LEVEL";
+    }
+    
+    return s
 }
 
 // Check tags


### PR DESCRIPTION
When playing as medic, downed players that are above or below you are hard to locate with just direction and distance. This patch should add an above/below/level display to help resolve that.

If you think this is a good idea, we should also consider giving the altitude difference explicitly, to give you a better idea of where someone is. I could imagine the proposed system being troublesome on maps like Launch Control, where someone could be down on the surface, a good 90 second walk from the lower levels.

I'm not sure about the use of the word 'level' to describe being at the same altitude. Sernix has a diverse playerbase, and I'm not sure how widely that meaning of the word is known to non native English speakers. Suggestions welcome.

This patch is untested and is not ready for merge. I've never worked with SourceMod and I'm honestly not sure how to go about setting up a proper test environment. I couldn't even check that it compiled with the sourcemod.net compiler, as it complains about not being able to read the included `insurgencydy.sp`, and I don't see an option to upload multiple files.

Take a look and let me know what you think.