### PR TITLE
Do not respawn players being revived

### DIFF
--- a/scripting/c_dy_respawn_naong.sp
+++ b/scripting/c_dy_respawn_naong.sp
@@ -4430,6 +4430,9 @@ public Action:Timer_ReviveMonitor(Handle:timer, any:data)
 						
 						// Decrease revive remaining time
 						g_iReviveRemainingTime[iInjured]--;
+
+						//prevent respawn while reviving
+						g_iRespawnTimeRemaining[iInjured]++;
 					}
 					// Revive player
 					else if (g_iReviveRemainingTime[iInjured] <= 0)


### PR DESCRIPTION
This is a bit of a hack, and has some rough edges, but it should work.

This should stop players from respawning while a medic is trying to revive them. It's rather frustrating for both parties when this happens; the medic wasted time trying to revive, and the player wasted a life.

This implementation does have weird side effects. Multiple medics reviving the same player together will increase the target's respawn timer. The worst case scenario of all four medics reviving a critically wounded player at the same time, then abandoning after two seconds, would increase the timer by 6 seconds. More likely is two medics working on one target, which would result in the timer counting up instead of down. Weird, but hardly game breaking.

Assuming I understand the revive and respawn systems properly, this should work as is. However, I haven't done any testing to verify.

There are much more elegant ways to implement this, but I'm not sure how high your standards are, or how many changes you have on your local machine that a larger PR would conflict with, so I figured I'd just float a simple change and see what you thought. If you have suggestions for a more fleshed out patch, or if you have any other thoughts, let me know.