### PR TITLE
Despawn IEDs when triggering RoundEnd protection

### DIFF
--- a/scripting/roundendblock.sp
+++ b/scripting/roundendblock.sp
@@ -760,7 +760,20 @@ void RevivePlayers()
 			}
 		}
 	}
-	//TODO: Despawn dropped IEDs
+
+	//Despawn dropped IEDs
+	while (true)
+	{
+		new iIED = FindEntityByClassname(-1, "grenade_ied");
+		if (iIED > -1) //IED found
+		{
+			AcceptEntityInput(iIED, "KillHierarchy");
+		}
+		else
+		{
+			break;
+		}
+	}
 
 	iIsReviving = 0;
 	if (g_iRoundEndBlockDebug)

--- a/scripting/roundendblock.sp
+++ b/scripting/roundendblock.sp
@@ -740,8 +740,28 @@ void RevivePlayers()
 					}
 				}
 			}
+			else if (iTeam == TEAM_2)
+			{
+				//Despawn Insurgents with IEDs
+
+				//Get weapon handle
+				new ActiveWeapon = GetEntPropEnt(client, Prop_Data, "m_hActiveWeapon");
+				if (ActiveWeapon < 0)
+					continue;
+
+				// Get weapon name
+				decl String:sWeapon[32];
+				GetEdictClassname(ActiveWeapon, sWeapon, sizeof(sWeapon));
+
+				if (StrContains(sWeapon, "weapon_c4_ied") > -1)
+				{
+					AcceptEntityInput(client, "KillHierarchy");
+				}
+			}
 		}
 	}
+	//TODO: Despawn dropped IEDs
+
 	iIsReviving = 0;
 	if (g_iRoundEndBlockDebug)
 	{


### PR DESCRIPTION
This code is completely untested. Do not merge it without testing. It looks right and it compiles, that's about all I can say.

I've got some more tweaks I'd like to make on this. Proper communication between the suicide bomber and round end protection scripts would be nice. This will enable despawning dropped IEDs. It should also use the respawn script's `AddLifeForStaticKilling` function to preserve the spawn ticket.

If I get those working, I'll add them as further commits to this PR.